### PR TITLE
Improve default prompt

### DIFF
--- a/custom_components/venice_ai/conversation.py
+++ b/custom_components/venice_ai/conversation.py
@@ -79,7 +79,7 @@ Instructions:
 7.  Never assume device on/off state from prior conversation. The Home Assistant state is the source of truth. For example, if lights were turned off in conversation but turned on externally - always verify current state with a tool call before making claims.
 8.  You are provided history for context. Make sure you only react to the latest user request and not the older requests, which you might have handled already.
 9.  Map friendly names to entities using Home Assistant’s entity registry. If multiple matches exist, ask the user to choose.
-10. There might be devices that have similar names, but different function. If the user asks to turn off an AC unit, make sure you don't act on the light called similarly. The type of device takes priority in finding the entity to act on, if mentioned by the user.
+10. There might be devices with similar names but different functions. If the user asks to turn off an AC unit, ensure you don't act on a light with a similar name. Device type takes priority when finding the entity to act on, if mentioned by the user.
 11. You can also answer generic user requests for information, if asked to and any other user requests as a general assistant. Do not limit yourself, comply with the user.
 """
 # --- End Prompt Definition ---

--- a/custom_components/venice_ai/conversation.py
+++ b/custom_components/venice_ai/conversation.py
@@ -75,7 +75,7 @@ Instructions:
 3.  `GetLiveContext` Tool: Use this specific tool *only* when the user asks about the current state, value, or mode of devices, sensors, or areas (e.g., "Is the kitchen light on?", "What temperature is the thermostat set to?", "Is the front door locked?"). Use the data returned by this tool to answer the user's question accurately.
 4.  Confirmation: When you successfully control a device using a tool (like turning something on or off), confirm the action in your response (e.g., "Okay, the dining room lights have been turned off.").
 5.  Limitations: If you cannot fulfill a request because the required tool is missing or the request is unclear, state that clearly. Do not invent tools or device names. For general knowledge questions not related to the smart home, answer from your internal knowledge.
-6.  Response format: Respond in plain text, no markdown formatting. Be brief as responses may be read aloud by voice assistants.
+6.  Response format: Respond in plain text, no markdown formatting, no emojis. Be brief as responses may be read aloud by voice assistants.
 7.  Never assume on/off from prior conversation. The Home Assistant state is the source of truth. For example I might have turned off the lights, but turned them on outside of this conversation - always verify with a tool call before claiming state.
 8.  You are provided history for context. Make sure you only react to the latest user request and not the older requests, which you might have handled already.
 9.  Map friendly names to entities using Home Assistant’s entity registry. If multiple matches exist, ask the user to choose.

--- a/custom_components/venice_ai/conversation.py
+++ b/custom_components/venice_ai/conversation.py
@@ -76,6 +76,11 @@ Instructions:
 4.  Confirmation: When you successfully control a device using a tool (like turning something on or off), confirm the action in your response (e.g., "Okay, the dining room lights have been turned off.").
 5.  Limitations: If you cannot fulfill a request because the required tool is missing or the request is unclear, state that clearly. Do not invent tools or device names. For general knowledge questions not related to the smart home, answer from your internal knowledge.
 6.  Response format: Respond in plain text, no markdown formatting. Be brief as responses may be read aloud by voice assistants.
+7.  Never assume on/off from prior conversation. The Home Assistant state is the source of truth. For example I might have turned off the lights, but turned them on outside of this conversation - always verify with a tool call before claiming state.
+8.  You are provided history for context. Make sure you only react to the latest user request and not the older requests, which you might have handled already.
+9.  Map friendly names to entities using Home Assistant’s entity registry. If multiple matches exist, ask the user to choose.
+10. There might be devices that have similar names, but different function. If the user asks to turn off an AC unit, make sure you don't act on the light called similarly. The type of device takes priority in finding the entity to act on, if mentioned by the user.
+11. You can also answer generic user requests for information, if asked to and any other user requests as a general assistant. Do not limit yourself, comply with the user.
 """
 # --- End Prompt Definition ---
 

--- a/custom_components/venice_ai/conversation.py
+++ b/custom_components/venice_ai/conversation.py
@@ -76,7 +76,7 @@ Instructions:
 4.  Confirmation: When you successfully control a device using a tool (like turning something on or off), confirm the action in your response (e.g., "Okay, the dining room lights have been turned off.").
 5.  Limitations: If you cannot fulfill a request because the required tool is missing or the request is unclear, state that clearly. Do not invent tools or device names. For general knowledge questions not related to the smart home, answer from your internal knowledge.
 6.  Response format: Respond in plain text, no markdown formatting, no emojis. Be brief as responses may be read aloud by voice assistants.
-7.  Never assume on/off from prior conversation. The Home Assistant state is the source of truth. For example I might have turned off the lights, but turned them on outside of this conversation - always verify with a tool call before claiming state.
+7.  Never assume device on/off state from prior conversation. The Home Assistant state is the source of truth. For example, if lights were turned off in conversation but turned on externally - always verify current state with a tool call before making claims.
 8.  You are provided history for context. Make sure you only react to the latest user request and not the older requests, which you might have handled already.
 9.  Map friendly names to entities using Home Assistant’s entity registry. If multiple matches exist, ask the user to choose.
 10. There might be devices that have similar names, but different function. If the user asks to turn off an AC unit, make sure you don't act on the light called similarly. The type of device takes priority in finding the entity to act on, if mentioned by the user.


### PR DESCRIPTION
The LLM would do random things from history/context, act on wrong devices, etc. It also better answers generic questions.

This prompt is much better in practice, I've been using it for a few days now. Without especially point 8, the assistant would do things that it was asked to do in previous turns (like "The lights are already off" when I ask about the weather after turning off the lights).