### PR TITLE
expose different APIs as tools

### DIFF
--- a/custom_components/venice_ai/conversation.py
+++ b/custom_components/venice_ai/conversation.py
@@ -267,16 +267,16 @@ class VeniceAIConversationEntity(ConversationEntity):
         hass = self.hass
 
         try:
-            # 1. Update LLM Data using the provided chat_log
-            # This sets the system prompt and tool configuration in chat_log
+            # 1. Provide LLM data (prompt + selected tool providers) to the chat log
             prompt_template = options.get(CONF_PROMPT, DEFAULT_SYSTEM_PROMPT)
-            llm_api_id = options.get(CONF_LLM_HASS_API)
-            # This call should now work as chat_log is managed by the framework
-            await chat_log.async_update_llm_data(
-                 conversing_domain=DOMAIN,
-                 user_input=user_input,
-                 user_llm_hass_api=llm_api_id,
-                 user_llm_prompt=prompt_template
+            llm_api_ids = options.get(CONF_LLM_HASS_API) or []
+            if not isinstance(llm_api_ids, list):
+                llm_api_ids = []
+            await chat_log.async_provide_llm_data(
+                user_input.as_llm_context(DOMAIN),
+                llm_api_ids,
+                prompt_template,
+                user_input.extra_system_prompt,
             )
 
             # 2. Format tools for Venice API (using chat_log.llm_api)

--- a/custom_components/venice_ai/strings.json
+++ b/custom_components/venice_ai/strings.json
@@ -25,12 +25,12 @@
           "data": {
             "chat_model": "AI Model",
             "prompt": "System Prompt",
+            "llm_hass_api": "Control Home Assistant",
             "temperature": "Temperature (0-2)",
             "top_p": "Top P (0-1)",
             "max_tokens": "Max Tokens",
             "strip_thinking_response": "Strip thinking response (for reasoning models)",
-            "disable_thinking": "Disable thinking (for reasoning models)",
-            "llm_hass_api": "Home Assistant LLM API"
+            "disable_thinking": "Disable thinking (for reasoning models)"
           }
         }
       }


### PR DESCRIPTION
new flow that allows registration of different tools that might be provided by other extensions. This mirrors what ollama integration does.

some extensions can now provide tools for LLMs, but we need configuration flow to allow choosing them. The API was just one option before, now it is a list.