### PR TITLE
Expose HA-standard voice capabilities to select TTS model in Voice Assistant configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ The current default model is Llama 3.3 70B (llama-3.3-70b), which provides excel
 
 For reasoning models like Venice Reasoning (qwen-2.5-qwq-32b) or DeepSeek R1 671B, you can disable thinking for lower latency by enabling the "Disable thinking" option in the configuration.
 
+## Contributing
+Contributions are welcome. Please keep changes focused and include tests for bug fixes or new behavior.
+
+To run tests locally:
+```bash
+python3 -m pytest -q
+```
+
 ## Support
 If you encounter any issues or have feature requests, please open an issue on our [GitHub Issues page](https://github.com/grasponcrypto/venice_ai/issues).
 

--- a/custom_components/venice_ai/config_flow.py
+++ b/custom_components/venice_ai/config_flow.py
@@ -54,6 +54,7 @@ from .const import (
     RECOMMENDED_TTS_VOICE,
     RECOMMENDED_TTS_RESPONSE_FORMAT,
     RECOMMENDED_TTS_SPEED,
+    VENICE_TTS_VOICES,
 )
 # Import the default prompt from the updated conversation module
 try:
@@ -178,22 +179,9 @@ class VeniceAIOptionsFlow(OptionsFlow):
         models_options: list[SelectOptionDict] = [
               SelectOptionDict(value=RECOMMENDED_CHAT_MODEL, label="Default Model")
         ]
-        # Hardcoded list of available voices
-        hardcoded_voices = [
-            "af_alloy", "af_aoede", "af_bella", "af_heart", "af_jadzia", "af_jessica", "af_kore", "af_nicole", "af_nova", "af_river", "af_sarah", "af_sky",
-            "am_adam", "am_echo", "am_eric", "am_fenrir", "am_liam", "am_michael", "am_onyx", "am_puck", "am_santa",
-            "bf_alice", "bf_emma", "bf_lily",
-            "bm_daniel", "bm_fable", "bm_george", "bm_lewis",
-            "zf_xiaobei", "zf_xiaoni", "zf_xiaoxiao", "zf_xiaoyi",
-            "zm_yunjian", "zm_yunxi", "zm_yunxia", "zm_yunyang",
-            "ff_siwis", "hf_alpha", "hf_beta", "hm_omega", "hm_psi",
-            "if_sara", "im_nicola",
-            "jf_alpha", "jf_gongitsune", "jf_nezumi", "jf_tebukuro", "jm_kumo",
-            "pf_dora", "pm_alex", "pm_santa",
-            "ef_dora", "em_alex", "em_santa"
-        ]
         voices_options = [
-            SelectOptionDict(value=voice, label=voice) for voice in sorted(hardcoded_voices)
+            SelectOptionDict(value=voice, label=voice)
+            for voice in sorted(VENICE_TTS_VOICES)
         ]
 
         # Fetch models if client is available (best effort)

--- a/custom_components/venice_ai/const.py
+++ b/custom_components/venice_ai/const.py
@@ -35,5 +35,19 @@ RECOMMENDED_TTS_RESPONSE_FORMAT = "mp3"
 CONF_TTS_SPEED = "tts_speed"
 RECOMMENDED_TTS_SPEED = 1.0
 
+# Venice AI TTS voices (shared between config flow and TTS provider voice list)
+VENICE_TTS_VOICES = [
+    "af_alloy", "af_aoede", "af_bella", "af_heart", "af_jadzia", "af_jessica",
+    "af_kore", "af_nicole", "af_nova", "af_river", "af_sarah", "af_sky",
+    "am_adam", "am_echo", "am_eric", "am_fenrir", "am_liam", "am_michael",
+    "am_onyx", "am_puck", "am_santa", "bf_alice", "bf_emma", "bf_lily",
+    "bm_daniel", "bm_fable", "bm_george", "bm_lewis", "zf_xiaobei",
+    "zf_xiaoni", "zf_xiaoxiao", "zf_xiaoyi", "zm_yunjian", "zm_yunxi",
+    "zm_yunxia", "zm_yunyang", "ff_siwis", "hf_alpha", "hf_beta", "hm_omega",
+    "hm_psi", "if_sara", "im_nicola", "jf_alpha", "jf_gongitsune",
+    "jf_nezumi", "jf_tebukuro", "jm_kumo", "pf_dora", "pm_alex", "pm_santa",
+    "ef_dora", "em_alex", "em_santa",
+]
+
 # Venice AI doesn't have unsupported models list currently
 UNSUPPORTED_MODELS = []

--- a/custom_components/venice_ai/manifest.json
+++ b/custom_components/venice_ai/manifest.json
@@ -3,6 +3,7 @@
     "name": "VeniceAI",
     "version": "1.0.0",
     "documentation": "https://github.com/grasponcrypto/venice_ai",
+    "issue_tracker": "https://github.com/grasponcrypto/venice_ai/issues",
     "requirements": ["aiohttp>=3.8.0"],
     "dependencies": ["conversation"],
     "after_dependencies": ["assist_pipeline", "intent"],

--- a/custom_components/venice_ai/tts.py
+++ b/custom_components/venice_ai/tts.py
@@ -4,12 +4,28 @@ from __future__ import annotations
 import logging
 from typing import Any, AsyncGenerator
 
-from homeassistant.components.tts import TextToSpeechEntity, TtsAudioType
+from homeassistant.components.tts import (
+    ATTR_AUDIO_OUTPUT,
+    ATTR_VOICE,
+    TTSAudioRequest,
+    TTSAudioResponse,
+    TextToSpeechEntity,
+    TtsAudioType,
+    Voice,
+)
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .client import AsyncVeniceAIClient
+from .const import (
+    RECOMMENDED_TTS_MODEL,
+    RECOMMENDED_TTS_RESPONSE_FORMAT,
+    RECOMMENDED_TTS_SPEED,
+    RECOMMENDED_TTS_VOICE,
+    VENICE_TTS_VOICES,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,13 +50,18 @@ class VeniceAITTS(TextToSpeechEntity):
         """Initialize TTS entity."""
         self._client = client
         self._config_entry = config_entry
+        self._name = "Venice AI TTS"
         self._attr_unique_id = f"{config_entry.entry_id}_tts"
-        self._attr_name = "Venice AI TTS"
         self._attr_device_info = {
             "identifiers": {(config_entry.domain, config_entry.entry_id)},
             "name": "Venice AI",
             "manufacturer": "Venice AI",
         }
+
+    @property
+    def name(self) -> str:
+        """Friendly name for entity listing."""
+        return self._name
 
     @property
     def supported_languages(self) -> list[str]:
@@ -55,27 +76,42 @@ class VeniceAITTS(TextToSpeechEntity):
     @property
     def supported_options(self) -> list[str]:
         """Return list of supported options."""
-        return ["tts_voice", "tts_model", "tts_response_format", "tts_speed"]
+        return [
+            # Standard Home Assistant TTS options used by Voice Assistant UI.
+            ATTR_VOICE,
+            ATTR_AUDIO_OUTPUT,
+            # Backward-compatible integration-specific options.
+            "tts_voice",
+            "tts_model",
+            "tts_response_format",
+            "tts_speed",
+        ]
 
     @property
     def default_options(self) -> dict[str, Any]:
         """Return default options."""
         return {
-            "tts_voice": "bm_daniel",
-            "tts_model": "tts-kokoro",
-            "tts_response_format": "wav",
-            "tts_speed": 1.0
+            ATTR_AUDIO_OUTPUT: RECOMMENDED_TTS_RESPONSE_FORMAT,
+            "tts_voice": RECOMMENDED_TTS_VOICE,
+            "tts_model": RECOMMENDED_TTS_MODEL,
+            "tts_response_format": RECOMMENDED_TTS_RESPONSE_FORMAT,
+            "tts_speed": RECOMMENDED_TTS_SPEED,
         }
 
     async def async_get_tts_audio(
-        self, message: str, language: str, options: dict[str, Any]
+        self, message: str, language: str, options: dict[str, Any] | None = None
     ) -> TtsAudioType:
         """Generate TTS audio."""
-        # Get all options from parameters or use defaults
-        voice = options.get("tts_voice", "bm_daniel")
-        model = options.get("tts_model", "tts-kokoro")
-        response_format = options.get("tts_response_format", "wav")
-        speed = options.get("tts_speed", 1.0)
+        if options is None:
+            options = {}
+
+        # Support both Home Assistant standard keys and existing Venice keys.
+        voice = options.get(ATTR_VOICE) or options.get("tts_voice", RECOMMENDED_TTS_VOICE)
+        model = options.get("tts_model", RECOMMENDED_TTS_MODEL)
+        response_format = options.get(ATTR_AUDIO_OUTPUT) or options.get(
+            "tts_response_format", RECOMMENDED_TTS_RESPONSE_FORMAT
+        )
+        speed = options.get("tts_speed", RECOMMENDED_TTS_SPEED)
 
         _LOGGER.debug("Generating TTS for message: %s", message)
         _LOGGER.debug(
@@ -132,23 +168,24 @@ class VeniceAITTS(TextToSpeechEntity):
                       response_format, type(audio_data))
         return (response_format, audio_data)
 
-    async def async_get_tts_audio_stream(
-        self, message: str, language: str, options: dict[str, Any]
-    ) -> AsyncGenerator[tuple[bytes, str], None]:
-        """Generate streaming TTS audio."""
-        _LOGGER.debug("Streaming TTS requested for message: %s", message)
+    def async_get_supported_voices(self, language: str) -> list[Voice] | None:
+        """Return available Venice voices for Home Assistant voice selection."""
+        return [Voice(voice_id, voice_id) for voice_id in VENICE_TTS_VOICES]
 
-        # Generate full audio and yield as single chunk
-        # Real streaming would yield chunks as available
-        response_format, audio_data = await self.async_get_tts_audio(
-            message, language, options
+    async def async_stream_tts_audio(
+        self, request: TTSAudioRequest
+    ) -> TTSAudioResponse:
+        """Stream audio using a single generated chunk."""
+        message = "".join([chunk async for chunk in request.message_gen])
+        options = dict(request.options or {})
+
+        audio_format, audio_data = await self.async_get_tts_audio(
+            message, request.language, options
         )
+        if not audio_data or not audio_format:
+            raise HomeAssistantError(f"No TTS from {self.entity_id} for '{message}'")
 
-        # Determine content type from format
-        if response_format == "wav":
-            content_type = "audio/wav"
-        else:
-            content_type = "audio/mpeg"
+        async def gen() -> AsyncGenerator[bytes]:
+            yield audio_data
 
-        # Yield the audio result as tuple
-        yield (audio_data, content_type)
+        return TTSAudioResponse(audio_format, gen())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-asyncio
+voluptuous
+httpx

--- a/tests/hass_stubs.py
+++ b/tests/hass_stubs.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from collections.abc import AsyncGenerator
+
+
+def install_homeassistant_stubs() -> None:
+    """Install minimal Home Assistant module stubs for Venice tests."""
+    if "homeassistant" in sys.modules:
+        return
+
+    ha = types.ModuleType("homeassistant")
+    ha.__path__ = []
+
+    # homeassistant.const
+    ha.const = types.ModuleType("const")
+    ha.const.CONF_API_KEY = "api_key"
+    ha.const.CONF_LLM_HASS_API = "llm_hass_api"
+
+    # homeassistant.config_entries
+    ha.config_entries = types.ModuleType("config_entries")
+    ha.config_entries.ConfigFlowResult = dict
+
+    class _BaseConfigFlow:
+        def __init_subclass__(cls, *args, domain=None, **kwargs):
+            super().__init_subclass__(*args, **kwargs)
+            cls.domain = domain
+
+        def async_show_form(self, **kwargs):
+            return kwargs
+
+        def async_create_entry(self, **kwargs):
+            self.created_entry = kwargs
+            return kwargs
+
+    class _OptionsFlow:
+        def __init__(self, config_entry):
+            self.config_entry = config_entry
+            self.hass = None
+
+        def async_show_form(self, **kwargs):
+            return kwargs
+
+        def async_create_entry(self, **kwargs):
+            self.created_entry = kwargs
+            return kwargs
+
+    ha.config_entries.ConfigFlow = _BaseConfigFlow
+    ha.config_entries.OptionsFlow = _OptionsFlow
+    ha.config_entries.ConfigEntry = object
+
+    # homeassistant.core
+    ha.core = types.ModuleType("core")
+    ha.core.HomeAssistant = object
+
+    # homeassistant.helpers.*
+    ha.helpers = types.ModuleType("helpers")
+    ha.helpers.config_validation = types.ModuleType("config_validation")
+    ha.helpers.config_validation.string = str
+
+    ha.helpers.llm = types.ModuleType("llm")
+    ha.helpers.llm.async_get_apis = lambda hass: []
+
+    ha.helpers.selector = types.ModuleType("selector")
+
+    class _Selector:
+        def __init__(self, config=None):
+            self.config = config
+
+    class _SelectOptionDict(dict):
+        def __init__(self, value, label):
+            super().__init__(value=value, label=label)
+
+    class _SelectSelectorConfig:
+        def __init__(self, options=None, mode=None, multiple=False):
+            self.options = options or []
+            self.mode = mode
+            self.multiple = multiple
+
+    class _NumberSelectorConfig:
+        def __init__(self, min=None, max=None, step=None, mode=None):
+            self.min = min
+            self.max = max
+            self.step = step
+            self.mode = mode
+
+    ha.helpers.selector.BooleanSelector = _Selector
+    ha.helpers.selector.NumberSelector = _Selector
+    ha.helpers.selector.NumberSelectorConfig = _NumberSelectorConfig
+    ha.helpers.selector.SelectOptionDict = _SelectOptionDict
+    ha.helpers.selector.SelectSelector = _Selector
+    ha.helpers.selector.SelectSelectorConfig = _SelectSelectorConfig
+    ha.helpers.selector.SelectSelectorMode = types.SimpleNamespace(DROPDOWN="dropdown")
+    ha.helpers.selector.TemplateSelector = _Selector
+
+    ha.helpers.entity_platform = types.ModuleType("entity_platform")
+    ha.helpers.entity_platform.AddEntitiesCallback = object
+
+    # homeassistant.components.tts
+    ha.components = types.ModuleType("components")
+    ha.components.__path__ = []
+    tts = types.ModuleType("tts")
+    tts.__package__ = "homeassistant.components"
+    tts.__path__ = []
+    tts.ATTR_AUDIO_OUTPUT = "audio_output"
+    tts.ATTR_VOICE = "voice"
+    tts.TtsAudioType = tuple[str | None, bytes | None]
+    tts.TextToSpeechEntity = object
+
+    @dataclass
+    class Voice:
+        voice_id: str
+        name: str
+
+    @dataclass
+    class TTSAudioRequest:
+        language: str
+        options: dict
+        message_gen: AsyncGenerator[str, None]
+
+    @dataclass
+    class TTSAudioResponse:
+        extension: str
+        data_gen: AsyncGenerator[bytes, None]
+
+    tts.Voice = Voice
+    tts.TTSAudioRequest = TTSAudioRequest
+    tts.TTSAudioResponse = TTSAudioResponse
+    ha.components.tts = tts
+
+    ha.exceptions = types.ModuleType("exceptions")
+
+    class HomeAssistantError(Exception):
+        pass
+
+    ha.exceptions.HomeAssistantError = HomeAssistantError
+
+    # Register modules
+    sys.modules["homeassistant"] = ha
+    sys.modules["homeassistant.const"] = ha.const
+    sys.modules["homeassistant.config_entries"] = ha.config_entries
+    sys.modules["homeassistant.core"] = ha.core
+    sys.modules["homeassistant.helpers"] = ha.helpers
+    sys.modules["homeassistant.helpers.config_validation"] = ha.helpers.config_validation
+    sys.modules["homeassistant.helpers.llm"] = ha.helpers.llm
+    sys.modules["homeassistant.helpers.selector"] = ha.helpers.selector
+    sys.modules["homeassistant.helpers.entity_platform"] = ha.helpers.entity_platform
+    sys.modules["homeassistant.components"] = ha.components
+    sys.modules["homeassistant.components.tts"] = tts
+    sys.modules["homeassistant.exceptions"] = ha.exceptions
+
+    # Third-party dependency stubs used by venice_ai modules.
+    if "voluptuous" not in sys.modules:
+        vol = types.ModuleType("voluptuous")
+
+        class _Schema:
+            def __init__(self, schema):
+                self.schema = schema
+
+            def __call__(self, value):
+                return value
+
+        class _Marker:
+            def __init__(self, key, default=None, description=None):
+                self.key = key
+                self.default = default
+                self.description = description
+
+            def __hash__(self):
+                return hash((self.key, self.default))
+
+        vol.Schema = _Schema
+        vol.Required = lambda key, default=None, description=None: _Marker(
+            key, default=default, description=description
+        )
+        vol.Optional = lambda key, default=None, description=None: _Marker(
+            key, default=default, description=description
+        )
+        vol.In = lambda values: values
+        vol.All = lambda *validators: validators[0] if validators else (lambda x: x)
+        vol.Coerce = lambda _type: (lambda x: _type(x))
+        vol.Range = lambda min=None, max=None: ("range", min, max)
+        vol.Length = lambda min=None, max=None: ("length", min, max)
+        sys.modules["voluptuous"] = vol
+
+    if "httpx" not in sys.modules:
+        httpx = types.ModuleType("httpx")
+
+        class RequestError(Exception):
+            pass
+
+        class HTTPStatusError(Exception):
+            def __init__(self, message="", request=None, response=None):
+                super().__init__(message)
+                self.request = request
+                self.response = response
+
+        class AsyncClient:
+            async def get(self, *args, **kwargs):
+                raise NotImplementedError
+
+            async def post(self, *args, **kwargs):
+                raise NotImplementedError
+
+            def stream(self, *args, **kwargs):
+                raise NotImplementedError
+
+            async def aclose(self):
+                return None
+
+        httpx.RequestError = RequestError
+        httpx.HTTPStatusError = HTTPStatusError
+        httpx.AsyncClient = AsyncClient
+        sys.modules["httpx"] = httpx

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,106 @@
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from hass_stubs import install_homeassistant_stubs
+
+install_homeassistant_stubs()
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, BASE_DIR)
+
+
+def _install_venice_namespace_package() -> None:
+    """Avoid importing integration __init__.py during unit tests."""
+    if "custom_components" not in sys.modules:
+        pkg = types.ModuleType("custom_components")
+        pkg.__path__ = [os.path.join(BASE_DIR, "custom_components")]
+        sys.modules["custom_components"] = pkg
+
+    if "custom_components.venice_ai" not in sys.modules:
+        pkg = types.ModuleType("custom_components.venice_ai")
+        pkg.__path__ = [os.path.join(BASE_DIR, "custom_components", "venice_ai")]
+        sys.modules["custom_components.venice_ai"] = pkg
+
+
+_install_venice_namespace_package()
+cfg_flow = importlib.import_module("custom_components.venice_ai.config_flow")
+
+
+class DummyModels:
+    def __init__(self, result=None, error=None):
+        self.result = result if result is not None else [{"id": "m1"}]
+        self.error = error
+
+    async def list(self):
+        if self.error:
+            raise self.error
+        return self.result
+
+
+class DummyClient:
+    def __init__(self, api_key):
+        self.api_key = api_key
+        self.models = DummyModels()
+
+
+class DummyAPI:
+    def __init__(self, api_id, name):
+        self.id = api_id
+        self.name = name
+
+
+class DummyConfigEntry:
+    def __init__(self, options=None, runtime_data=None):
+        self.options = options or {}
+        self.runtime_data = runtime_data
+
+
+@pytest.mark.asyncio
+async def test_config_flow_user_step_creates_entry(monkeypatch):
+    monkeypatch.setattr(cfg_flow, "AsyncVeniceAIClient", DummyClient)
+    flow = cfg_flow.VeniceAIConfigFlow()
+
+    result = await flow.async_step_user({"api_key": "k"})
+
+    assert result["title"] == "Venice AI"
+    assert result["data"]["api_key"] == "k"
+    assert result["options"]["chat_model"] == cfg_flow.RECOMMENDED_CHAT_MODEL
+    assert result["options"]["llm_hass_api"] == []
+    assert "prompt" in result["options"]
+
+
+@pytest.mark.asyncio
+async def test_config_flow_user_step_invalid_auth(monkeypatch):
+    class FailingClient:
+        def __init__(self, api_key):
+            self.models = DummyModels(error=cfg_flow.AuthenticationError("nope"))
+
+    monkeypatch.setattr(cfg_flow, "AsyncVeniceAIClient", FailingClient)
+    flow = cfg_flow.VeniceAIConfigFlow()
+
+    result = await flow.async_step_user({"api_key": "bad"})
+
+    assert result["step_id"] == "user"
+    assert result["errors"]["base"] == "invalid_auth"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_sanitizes_llm_api_ids(monkeypatch):
+    apis = [DummyAPI("valid_api", "Valid API"), DummyAPI("other_api", "Other API")]
+    monkeypatch.setattr(cfg_flow.llm, "async_get_apis", lambda hass: apis)
+
+    entry = DummyConfigEntry(options={"llm_hass_api": ["stale_api"]}, runtime_data=None)
+    flow = cfg_flow.VeniceAIOptionsFlow(entry)
+    flow.hass = object()
+    # VeniceAIOptionsFlow.__init__ does not call super(), so set this explicitly
+    # for the lightweight stub environment.
+    flow.config_entry = entry
+
+    result = await flow.async_step_init({"llm_hass_api": ["valid_api", "unknown_api"]})
+
+    assert result["data"]["llm_hass_api"] == ["valid_api"]

--- a/tests/test_tts_provider.py
+++ b/tests/test_tts_provider.py
@@ -1,0 +1,106 @@
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from hass_stubs import install_homeassistant_stubs
+
+install_homeassistant_stubs()
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, BASE_DIR)
+
+
+def _install_venice_namespace_package() -> None:
+    """Avoid importing integration __init__.py during unit tests."""
+    if "custom_components" not in sys.modules:
+        pkg = types.ModuleType("custom_components")
+        pkg.__path__ = [os.path.join(BASE_DIR, "custom_components")]
+        sys.modules["custom_components"] = pkg
+
+    if "custom_components.venice_ai" not in sys.modules:
+        pkg = types.ModuleType("custom_components.venice_ai")
+        pkg.__path__ = [os.path.join(BASE_DIR, "custom_components", "venice_ai")]
+        sys.modules["custom_components.venice_ai"] = pkg
+
+
+_install_venice_namespace_package()
+tts_module = importlib.import_module("custom_components.venice_ai.tts")
+const_module = importlib.import_module("custom_components.venice_ai.const")
+
+
+class DummySpeech:
+    def __init__(self):
+        self.calls = []
+
+    async def generate(self, **kwargs):
+        self.calls.append(kwargs)
+        return b"audio-bytes"
+
+
+class DummyClient:
+    def __init__(self):
+        self.speech = DummySpeech()
+
+
+class DummyEntry:
+    def __init__(self):
+        self.entry_id = "entry-1"
+        self.domain = "venice_ai"
+
+
+@pytest.mark.asyncio
+async def test_supported_voices_exposed_for_voice_assistant_ui():
+    provider = tts_module.VeniceAITTS(DummyClient(), DummyEntry())
+    voices = provider.async_get_supported_voices("en")
+
+    assert voices is not None
+    assert len(voices) == len(const_module.VENICE_TTS_VOICES)
+    assert voices[0].voice_id == const_module.VENICE_TTS_VOICES[0]
+
+
+@pytest.mark.asyncio
+async def test_tts_audio_prefers_standard_ha_options():
+    client = DummyClient()
+    provider = tts_module.VeniceAITTS(client, DummyEntry())
+    fmt, data = await provider.async_get_tts_audio(
+        "hello",
+        "en",
+        {
+            "voice": "af_alloy",
+            "audio_output": "mp3",
+            "tts_model": "tts-kokoro",
+            "tts_speed": 1.4,
+        },
+    )
+
+    assert fmt == "mp3"
+    assert data == b"audio-bytes"
+    assert client.speech.calls[0]["voice"] == "af_alloy"
+    assert client.speech.calls[0]["response_format"] == "mp3"
+    assert client.speech.calls[0]["model"] == "tts-kokoro"
+    assert client.speech.calls[0]["speed"] == 1.4
+
+
+@pytest.mark.asyncio
+async def test_tts_audio_supports_legacy_venice_option_keys():
+    client = DummyClient()
+    provider = tts_module.VeniceAITTS(client, DummyEntry())
+    fmt, _ = await provider.async_get_tts_audio(
+        "hello",
+        "en",
+        {
+            "tts_voice": "bm_daniel",
+            "tts_response_format": "wav",
+            "tts_model": "tts-kokoro",
+            "tts_speed": 1.0,
+        },
+    )
+
+    assert fmt == "wav"
+    assert client.speech.calls[0]["voice"] == "bm_daniel"
+    assert client.speech.calls[0]["response_format"] == "wav"
+


### PR DESCRIPTION
Fixed Venice TTS provider integration so it follows Home Assistant’s expected TTS provider interface more closely, including voice support exposure for Voice Assistant configuration.

Also added some basic tests and a requirements-dev file for the tests.

**Before**:

<img width="409" height="200" alt="venice ai tts" src="https://github.com/user-attachments/assets/e5bd31c3-a9e0-47cc-af90-2634f1f48ee6" />


**After**:
<img width="416" height="247" alt="venice after" src="https://github.com/user-attachments/assets/24176c7c-a7a5-4710-b888-6851167b28b9" />
