### PR TITLE
Fix options flow cannot_connect: use tts/asr instead of retired "audio" model type

### DIFF
--- a/custom_components/venice_ai/config_flow.py
+++ b/custom_components/venice_ai/config_flow.py
@@ -207,7 +207,15 @@ class VeniceAIOptionsFlow(OptionsFlow):
 
                 # Fetch audio models for TTS and STT
                 LOGGER.debug("Fetching audio models for TTS/STT options flow")
-                audio_models_response = await self._client.models.list(model_type="audio")
+                # Venice retired the "audio" model type; it is now split into "tts" and "asr".
+                audio_models_response = []
+                for _audio_type in ("tts", "asr"):
+                    try:
+                        _resp = await self._client.models.list(model_type=_audio_type)
+                        if isinstance(_resp, list):
+                            audio_models_response.extend(_resp)
+                    except VeniceAIError as err:
+                        LOGGER.warning("Failed to fetch %s models: %s", _audio_type, err)
 
                 if audio_models_response and isinstance(audio_models_response, list):
                     fetched_tts_models = []


### PR DESCRIPTION
## What

Fixes the **Options dialog failing with `cannot_connect`** for configured Venice AI entries.

Closes #27.

## Why

The options flow lists audio models using the retired `audio` model type:

```python
audio_models_response = await self._client.models.list(model_type="audio")
```

Venice split `audio` into `tts` / `asr`, so `/models?type=audio` now returns **HTTP 400**:

```
Invalid enum value. Expected 'asr' | 'embedding' | 'image' | 'music' | 'text' | 'tts' | 'upscale' | 'inpaint' | 'video', received 'audio'
```

`Models.list()` raises `VeniceAIError`, which the options flow maps to `cannot_connect`, taking down the whole dialog. The conversation agent is unaffected because runtime never lists models.

## How

- Fetch `tts` and `asr` separately and combine the results.
- Wrap each sub-fetch in `try/except VeniceAIError` and log a warning on failure, so a single failed audio fetch can never take down the options flow again.
- Downstream TTS/STT detection (`supportsTTS` / `supportsTranscription` / id-substring matching) already operates on the combined list, so no further changes needed.

## Testing

Verified against the live Venice API: `type=audio` → 400, `type=tts`/`type=asr` → 200. Patched integration loads cleanly and the Options dialog opens without `cannot_connect`.
