### PR TITLE
Fix Home Assistant control on HA 2026.6 (llm helper API changes)

### DIFF
--- a/custom_components/venice_ai/config_flow.py
+++ b/custom_components/venice_ai/config_flow.py
@@ -481,25 +481,30 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
         return chat_options, tts_info, stt_options, errors
 
     async def _fetch_llm_api_options(self) -> list[SelectOptionDict]:
-        """Return a list of available HA LLM API IDs as SelectOptionDicts."""
-        none_option = SelectOptionDict(label="None (disabled)", value="")
-        api_ids: list[str] = []
+        """Return the registered HA LLM APIs as SelectOptionDicts.
+
+        Uses ``llm.async_get_apis`` (HA 2025+), which is a synchronous callback
+        returning ``API`` objects with ``id`` and ``name`` attributes. The
+        legacy ``async_get_api_list`` helper (which returned id strings) was
+        removed, so the old code path always fell through to an empty list and
+        the control selector showed only "None".
+        """
         try:
+            if hasattr(llm, "async_get_apis"):
+                return [
+                    SelectOptionDict(label=api.name, value=api.id)
+                    for api in llm.async_get_apis(self.hass)
+                ]
+            # Legacy fallback for very old cores that still expose the list helper.
             if hasattr(llm, "async_get_api_list"):
                 api_ids = await llm.async_get_api_list(self.hass)
-            else:
-                try:
-                    await llm.async_get_api(self.hass, "assist")
-                    api_ids = ["assist"]
-                except Exception:
-                    pass
-        except Exception:
-            _LOGGER.debug("Could not fetch LLM API list; using fallback")
-            api_ids = ["assist"]
-
-        return [none_option] + [
-            SelectOptionDict(label=api_id, value=api_id) for api_id in api_ids
-        ]
+                return [
+                    SelectOptionDict(label=api_id, value=api_id)
+                    for api_id in api_ids
+                ]
+        except Exception:  # pragma: no cover - defensive
+            _LOGGER.debug("Could not fetch LLM API list", exc_info=True)
+        return []
 
     def _validate_numeric_options(
         self,
@@ -545,7 +550,7 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
         atomically on submit — no re-render handshake required.
         """
         if llm_api_options is None:
-            llm_api_options = [SelectOptionDict(label="None (disabled)", value="")]
+            llm_api_options = []
 
         return vol.Schema(
             {
@@ -569,7 +574,7 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
                     SelectSelectorConfig(
                         options=llm_api_options,
                         mode=SelectSelectorMode.DROPDOWN,
-                        custom_value=True,
+                        multiple=True,
                     )
                 ),
                 vol.Optional(CONF_STRIP_THINKING_RESPONSE): BooleanSelector(),
@@ -652,14 +657,13 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
             if CONF_LLM_HASS_API in user_input and not user_input[CONF_LLM_HASS_API]:
                 user_input = {k: v for k, v in user_input.items() if k != CONF_LLM_HASS_API}
             elif CONF_LLM_HASS_API in user_input and user_input[CONF_LLM_HASS_API]:
-                try:
-                    await llm.async_get_api(self.hass, user_input[CONF_LLM_HASS_API])
-                except Exception as err:
-                    _LOGGER.warning(
-                        "Invalid LLM API ID '%s': %s",
-                        user_input[CONF_LLM_HASS_API],
-                        err,
-                    )
+                selected = user_input[CONF_LLM_HASS_API]
+                if isinstance(selected, str):
+                    selected = [selected]
+                available = {api.id for api in llm.async_get_apis(self.hass)}
+                invalid = [api_id for api_id in selected if api_id not in available]
+                if invalid:
+                    _LOGGER.warning("Invalid LLM API ID(s): %s", invalid)
                     errors[CONF_LLM_HASS_API] = "invalid_llm_api"
 
             # --- Validate numeric ranges ---
@@ -714,7 +718,7 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
             CONF_MAX_TOKENS: RECOMMENDED_MAX_TOKENS,
             CONF_TOP_P: RECOMMENDED_TOP_P,
             CONF_TEMPERATURE: RECOMMENDED_TEMPERATURE,
-            CONF_LLM_HASS_API: "",
+            CONF_LLM_HASS_API: [],
             CONF_STRIP_THINKING_RESPONSE: RECOMMENDED_STRIP_THINKING_RESPONSE,
             CONF_DISABLE_THINKING: RECOMMENDED_DISABLE_THINKING,
             CONF_STREAM_RESPONSE: RECOMMENDED_STREAM_RESPONSE,

--- a/custom_components/venice_ai/conversation.py
+++ b/custom_components/venice_ai/conversation.py
@@ -10,9 +10,9 @@ from collections import OrderedDict
 from typing import Any
 
 from homeassistant.components.conversation import (
-    HOME_ASSISTANT_AGENT,
     MATCH_ALL,
     ConversationEntity,
+    ConversationEntityFeature,
     ConversationInput,
     ConversationResult,
     ChatLog,
@@ -23,7 +23,7 @@ from homeassistant.components.conversation import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LLM_HASS_API
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, TemplateError
 from homeassistant.helpers import intent, llm, device_registry as dr, selector
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -281,6 +281,11 @@ class VeniceAIConversationEntity(ConversationEntity):
         self._service = VeniceConversationService(self._client)
         self._attr_unique_id = f"{entry.entry_id}_conversation"
         self._attr_name = entry.title
+        # Advertise CONTROL when a Home Assistant LLM API is configured, so the
+        # frontend stops showing "this assistant cannot control your home" and
+        # the assist pipeline treats this agent as control-capable.
+        if entry.options.get(CONF_LLM_HASS_API):
+            self._attr_supported_features = ConversationEntityFeature.CONTROL
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name=entry.title,
@@ -460,14 +465,13 @@ class VeniceAIConversationEntity(ConversationEntity):
         tools: list[llm.Tool] = []
         if llm_api:
             try:
-                llm_context = llm.LLMContext(
-                    platform=DOMAIN,
-                    context=user_input.context,
-                    user_prompt=user_input.text,
-                    language=user_input.language,
-                    assistant=HOME_ASSISTANT_AGENT,
-                    device_id=user_input.device_id,
-                )
+                # Build the context via the canonical helper so the `assistant`
+                # key matches HA's exposure model (conversation.DOMAIN). Setting
+                # it to HOME_ASSISTANT_AGENT made async_should_expose look under
+                # the wrong key, so every exposed entity was reported as not
+                # exposed (MatchFailedReason.ASSISTANT) and control silently
+                # found nothing.
+                llm_context = user_input.as_llm_context(DOMAIN)
                 api = await llm.async_get_api(self.hass, llm_api, llm_context)
                 tools = list(api.tools)
             except Exception as err:
@@ -504,7 +508,7 @@ class VeniceAIConversationEntity(ConversationEntity):
 
         try:
             _trim_chat_log(chat_log)
-            for iteration in range(max_tool_iterations):
+            for iteration in range(int(max_tool_iterations)):
                 messages = _convert_chat_log_to_venice_messages(
                     chat_log, system_prompt, strip_thinking=strip_thinking
                 )
@@ -644,13 +648,10 @@ class VeniceAIConversationEntity(ConversationEntity):
                                 tool_input = llm.ToolInput(
                                     tool_name=tool_name,
                                     tool_args=tool_args,
-                                    platform=DOMAIN,
-                                    context=user_input.context,
-                                    user_prompt=user_input.text,
-                                    assistant=HOME_ASSISTANT_AGENT,
-                                    device_id=user_input.device_id,
                                 )
-                                tool_result = await tool.async_call(self.hass, tool_input)
+                                tool_result = await tool.async_call(
+                                    self.hass, tool_input, llm_context
+                                )
                             except Exception as tool_err:
                                 _LOGGER.warning("Tool %s failed: %s", tool_name, tool_err)
                                 tool_result = {"error": str(tool_err)}
@@ -661,7 +662,9 @@ class VeniceAIConversationEntity(ConversationEntity):
                         tool_result = {"error": f"Tool {tool_name} not found"}
 
                     tool_result_content = ToolResultContent(
+                        agent_id=DOMAIN,
                         tool_call_id=call_id,
+                        tool_name=tool_name,
                         tool_result=tool_result,
                     )
                     chat_log.content.append(tool_result_content)
@@ -739,10 +742,14 @@ class VeniceAIConversationEntity(ConversationEntity):
         )
 
     async def async_added_to_hass(self) -> None:
-        """Register update listener and start the HIGH-2 cleanup loop."""
-        self.entry.async_on_unload(
-            self.entry.add_update_listener(self._async_entry_updated)
-        )
+        """Start the HIGH-2 cleanup loop.
+
+        No options-update listener is registered here: the options flow
+        subclasses OptionsFlowWithReload, which reloads the config entry (and
+        therefore recreates this entity) whenever options are saved. Adding a
+        manual update listener on top of that raises ValueError on save in
+        modern HA cores.
+        """
         # HIGH-2: start the periodic cleanup task. Cancelled on unload.
         if self._cleanup_task is None or self._cleanup_task.done():
             self._cleanup_task = self.hass.async_create_background_task(
@@ -753,12 +760,6 @@ class VeniceAIConversationEntity(ConversationEntity):
     async def async_will_remove_from_hass(self) -> None:
         """HIGH-2: stop the cleanup task when the entity is being removed."""
         self._cancel_cleanup()
-
-    @callback
-    def _async_entry_updated(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Handle options update."""
-        self.entry = entry
-        self._client = entry.runtime_data.client
 
 
 async def async_setup_entry(


### PR DESCRIPTION
## Problem

On current Home Assistant cores (tested on **2026.6.4**), the Venice AI
conversation agent can no longer control the home. The **Control Home
Assistant** selector shows only **None**, selecting an API fails with
*"the selected option is not available"*, the chat shows *"this assistant
cannot control your home"*, and conversations error out. The 0.9.x rewrite
relies on several `homeassistant.helpers.llm` APIs that have since changed.

## Root causes & fixes

**`config_flow.py`**
- `llm.async_get_api_list` was **removed**. `_fetch_llm_api_options` gated on
  `hasattr(llm, "async_get_api_list")`, so it always fell through to an empty
  list → selector only offered *None*. Now uses **`llm.async_get_apis`** (a
  synchronous callback returning `API` objects with `id`/`name`).
- The control selector is now a **multiple-select**, so several LLM APIs (e.g.
  `Assist` + a custom API) can be enabled together. Default is now `[]`.
- Options validation called the removed 2-arg `llm.async_get_api(hass, id)`
  (it now requires an `LLMContext`). Replaced with a membership check against
  `llm.async_get_apis()`.

**`conversation.py`**
- The entity never declared **`ConversationEntityFeature.CONTROL`**, so the
  frontend always reported it couldn't control the home. Now set when an LLM
  API is configured.
- **`LLMContext`** no longer accepts `user_prompt`; passing it raised
  `TypeError`, which was swallowed → **no tools were ever attached**. Removed.
- **`ToolInput`** no longer accepts `platform/context/user_prompt/assistant/
  device_id`, and **`Tool.async_call`** now requires `llm_context`. Updated.
- **`ToolResultContent`** now requires `agent_id` and `tool_name`. Supplied
  (raised `TypeError` the moment a tool was actually invoked).
- `range(max_tool_iterations)` threw `TypeError: 'float' object cannot be
  interpreted as an integer` (the `NumberSelector` yields a float). Cast to int.
- Removed the manual `add_update_listener`: combined with `OptionsFlowWithReload`
  it raises `ValueError: Config entry update listeners should not be used with
  OptionsFlowWithReload` on every options save.

## Testing

Deployed on HA 2026.6.4: the control selector lists **Assist** and custom APIs,
multiple can be selected, options save without error, the "cannot control"
banner is gone, and spoken/typed commands actuate exposed devices.
