### PR TITLE
Advertise CONTROL feature + allow multiple HA control APIs

### DIFF
--- a/custom_components/venice_ai/config_flow.py
+++ b/custom_components/venice_ai/config_flow.py
@@ -488,8 +488,9 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
         ``async_get_apis`` exists but returns an empty iterable (e.g. on some
         HA versions) we still fall back to probing known API IDs directly.
         """
-        none_option = SelectOptionDict(label="None (disabled)", value="")
-        api_options: list[SelectOptionDict] = [none_option]
+        # The control field is a multiple-select, so an explicit "None" entry is
+        # not needed — an empty selection disables control.
+        api_options: list[SelectOptionDict] = []
 
         # Method 1: async_get_apis (HA ≥ 2024.x – returns API objects with .id/.name)
         if hasattr(llm, "async_get_apis"):
@@ -501,7 +502,7 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
                     )
                 _LOGGER.debug("Found %d LLM API(s) via async_get_apis", len(apis))
                 # Only return if we actually discovered something; otherwise fall through.
-                if len(api_options) > 1:
+                if api_options:
                     return api_options
             except Exception as err:
                 _LOGGER.debug("async_get_apis failed: %s", err)
@@ -522,7 +523,7 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
                     _LOGGER.debug(
                         "Found %d LLM API(s) via async_get_api_list", len(api_ids)
                     )
-                    if len(api_options) > 1:
+                    if api_options:
                         return api_options
             except Exception as err:
                 _LOGGER.debug("async_get_api_list failed: %s", err)
@@ -641,12 +642,13 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
                 ),
                 vol.Optional(
                     CONF_LLM_HASS_API,
-                    default="assist",  # Default to "assist" for HA control
+                    default=["assist"],  # Default to "assist" for HA control
                 ): SelectSelector(
                     SelectSelectorConfig(
                         options=llm_api_options,
                         mode=SelectSelectorMode.DROPDOWN,
-                        sort=False,  # Keep "None" first
+                        multiple=True,  # allow enabling several APIs at once
+                        sort=False,
                     )
                 ),
                 vol.Optional(CONF_STRIP_THINKING_RESPONSE): BooleanSelector(),
@@ -795,7 +797,7 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
             CONF_MAX_TOKENS: RECOMMENDED_MAX_TOKENS,
             CONF_TOP_P: RECOMMENDED_TOP_P,
             CONF_TEMPERATURE: RECOMMENDED_TEMPERATURE,
-            CONF_LLM_HASS_API: "assist",  # Default to "assist" for HA control
+            CONF_LLM_HASS_API: ["assist"],  # Default to "assist" for HA control
             CONF_STRIP_THINKING_RESPONSE: RECOMMENDED_STRIP_THINKING_RESPONSE,
             CONF_DISABLE_THINKING: RECOMMENDED_DISABLE_THINKING,
             CONF_STREAM_RESPONSE: RECOMMENDED_STREAM_RESPONSE,
@@ -812,6 +814,12 @@ class VeniceAIOptionsFlow(_OptionsFlowBase):
         # add_suggested_values_to_schema, but they are used by
         # _resolve_combined_tts_value below.
         suggested_values.update(self.config_entry.options)
+        # The control field is now a multiple-select. Installs created with the
+        # earlier single-select stored it as a plain string; coerce to a list so
+        # the widget pre-selects it correctly (and an empty string -> []).
+        _llm_val = suggested_values.get(CONF_LLM_HASS_API)
+        if isinstance(_llm_val, str):
+            suggested_values[CONF_LLM_HASS_API] = [_llm_val] if _llm_val else []
         if user_input is not None:
             suggested_values.update(user_input)
 

--- a/custom_components/venice_ai/conversation.py
+++ b/custom_components/venice_ai/conversation.py
@@ -14,6 +14,7 @@ from homeassistant.components.conversation import (
     HOME_ASSISTANT_AGENT,
     MATCH_ALL,
     ConversationEntity,
+    ConversationEntityFeature,
     ConversationInput,
     ConversationResult,
     ChatLog,
@@ -308,6 +309,11 @@ class VeniceAIConversationEntity(ConversationEntity):
         self._service = VeniceConversationService(self._client)
         self._attr_unique_id = f"{entry.entry_id}_conversation"
         self._attr_name = entry.title
+        # Advertise CONTROL when a Home Assistant LLM API is configured so the
+        # frontend stops showing "this assistant cannot control your home" and
+        # the assist pipeline treats this agent as control-capable.
+        if entry.options.get(CONF_LLM_HASS_API):
+            self._attr_supported_features = ConversationEntityFeature.CONTROL
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name=entry.title,


### PR DESCRIPTION
Two small follow-ups on top of the recent HA-control fixes (0.9.x). Both are
additive and the runtime control path is unchanged.

## 1. Advertise `ConversationEntityFeature.CONTROL`

`VeniceAIConversationEntity` never set `supported_features`, so even with a
Home Assistant LLM API configured the frontend permanently shows **"this
assistant cannot control your home"**, and the assist pipeline doesn't treat the
agent as control-capable. This sets `ConversationEntityFeature.CONTROL` when an
LLM API is configured (matching how HA's own conversation agents behave).

## 2. Allow enabling multiple HA control APIs

The **Control Home Assistant** option is now a multiple-select, so several LLM
APIs can be active at once (e.g. **Assist** plus a custom API such as a SimpleX
integration). This needs no runtime change: `llm.async_get_api` /
`chat_log.async_provide_llm_data` already accept a list of API ids and merge
them into a single `APIInstance`.

Details:
- Drop the synthetic `None (disabled)` entry — an empty multi-select already
  means "no control".
- Default to `["assist"]`.
- When rendering the options form, coerce a previously-stored single string
  value to a list, so installs created with the old single-select upgrade
  cleanly without losing their selection.

## Testing

- `python -m pytest tests/test_config_flow_tts.py` → passes.
- Full suite: same 8 pre-existing failures as `main` (in
  `_convert_schema_to_hashable` / `chat_stream`), unrelated to this change; no
  new failures introduced.
- Deployed on HA 2026.6: the control field shows checkboxes for all registered
  APIs, multiple can be enabled, the "cannot control your home" banner is gone,
  and exposed devices are actuated.
