### PR TITLE
fix: add missing reauth_confirm step strings for reauth UI

### DIFF
--- a/custom_components/venice_ai/strings.json
+++ b/custom_components/venice_ai/strings.json
@@ -6,6 +6,13 @@
           "data": {
             "api_key": "Venice AI API Key"
           }
+        },
+        "reauth_confirm": {
+          "title": "Re-authenticate Venice AI",
+          "description": "The Venice AI API key for {name} is no longer valid. Please enter a new API key to reconnect.",
+          "data": {
+            "api_key": "Venice AI API Key"
+          }
         }
       },
       "error": {

--- a/custom_components/venice_ai/translations/en.json
+++ b/custom_components/venice_ai/translations/en.json
@@ -6,6 +6,13 @@
                 "data": {
                     "api_key": "Venice AI API Key"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Re-authenticate Venice AI",
+                "description": "The Venice AI API key for {name} is no longer valid. Please enter a new API key to reconnect.",
+                "data": {
+                    "api_key": "Venice AI API Key"
+                }
             }
         },
         "error": {


### PR DESCRIPTION
## Summary
- Fixes the blank re-authentication dialog that appears when a Venice AI API key becomes invalid.
- Adds the missing `config.step.reauth_confirm` translation strings to both `strings.json` and `translations/en.json`.
- Includes the `{name}` placeholder already provided by `async_step_reauth_confirm` so the dialog shows which entry needs re-auth.

## Changes
- `custom_components/venice_ai/strings.json`
- `custom_components/venice_ai/translations/en.json`

## Test plan
- [x] Validated both JSON files parse successfully
- [x] Confirmed `reauth_confirm` step has title, description with `{name}`, and `api_key` field label
- [ ] In HA: force reauth (invalid API key) and confirm the dialog shows title + description instead of a blank UI
- [ ] Enter a valid API key and confirm reauth succeeds (`reauth_successful` abort path)

Fixes #34
